### PR TITLE
fix: CLIN-2475 override ant form tooltip cursor, set to default

### DIFF
--- a/themes/clin/antd-clin-theme.less
+++ b/themes/clin/antd-clin-theme.less
@@ -153,6 +153,9 @@ body {
 
 // Tooltip
 @tooltip-bg: @gray-9;
+.ant-form-item-label > label .ant-form-item-tooltip {
+  cursor: default;
+}
 
 // Modal
 //@modal-mask-bg: fade(#050517, 60%);

--- a/themes/clin/dist/antd.css
+++ b/themes/clin/dist/antd.css
@@ -665,8 +665,6 @@ html {
 }
 .ant-slide-up-enter,
 .ant-slide-up-appear {
-  transform: scale(0);
-  transform-origin: 0% 0%;
   opacity: 0;
   animation-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
 }
@@ -696,8 +694,6 @@ html {
 }
 .ant-slide-down-enter,
 .ant-slide-down-appear {
-  transform: scale(0);
-  transform-origin: 0% 0%;
   opacity: 0;
   animation-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
 }
@@ -727,8 +723,6 @@ html {
 }
 .ant-slide-left-enter,
 .ant-slide-left-appear {
-  transform: scale(0);
-  transform-origin: 0% 0%;
   opacity: 0;
   animation-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
 }
@@ -758,8 +752,6 @@ html {
 }
 .ant-slide-right-enter,
 .ant-slide-right-appear {
-  transform: scale(0);
-  transform-origin: 0% 0%;
   opacity: 0;
   animation-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
 }
@@ -1442,7 +1434,7 @@ html {
   transform: translateX(-50%);
   transition: top 0.3s ease-in-out;
 }
-.ant-anchor-ink-ball.ant-anchor-ink-ball-visible {
+.ant-anchor-ink-ball.visible {
   display: inline-block;
 }
 .ant-anchor-fixed .ant-anchor-ink .ant-anchor-ink-ball {
@@ -4064,109 +4056,6 @@ a.ant-btn-lg {
 a.ant-btn-sm {
   line-height: 22px;
 }
-.ant-btn-compact-item:not(.ant-btn-compact-last-item):not(.ant-btn-compact-item-rtl) {
-  margin-right: -1px;
-}
-.ant-btn-compact-item:not(.ant-btn-compact-last-item).ant-btn-compact-item-rtl {
-  margin-left: -1px;
-}
-.ant-btn-compact-item:hover,
-.ant-btn-compact-item:focus,
-.ant-btn-compact-item:active {
-  z-index: 2;
-}
-.ant-btn-compact-item[disabled] {
-  z-index: 0;
-}
-.ant-btn-compact-item:not(.ant-btn-compact-first-item):not(.ant-btn-compact-last-item).ant-btn {
-  border-radius: 0;
-}
-.ant-btn-compact-item.ant-btn.ant-btn-compact-first-item:not(.ant-btn-compact-last-item):not(.ant-btn-compact-item-rtl) {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-.ant-btn-compact-item.ant-btn.ant-btn-compact-last-item:not(.ant-btn-compact-first-item):not(.ant-btn-compact-item-rtl) {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.ant-btn-compact-item.ant-btn.ant-btn-compact-item-rtl.ant-btn-compact-first-item:not(.ant-btn-compact-last-item) {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.ant-btn-compact-item.ant-btn.ant-btn-compact-item-rtl.ant-btn-compact-last-item:not(.ant-btn-compact-first-item) {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-.ant-btn-icon-only.ant-btn-compact-item {
-  flex: none;
-}
-.ant-btn-compact-item.ant-btn-primary:not([disabled]) + .ant-btn-compact-item.ant-btn-primary:not([disabled]) {
-  position: relative;
-}
-.ant-btn-compact-item.ant-btn-primary:not([disabled]) + .ant-btn-compact-item.ant-btn-primary:not([disabled])::after {
-  position: absolute;
-  top: -1px;
-  left: -1px;
-  display: inline-block;
-  width: 1px;
-  height: calc(100% + 1px * 2);
-  background-color: #1c81b0;
-  content: ' ';
-}
-.ant-btn-compact-item-rtl.ant-btn-compact-first-item.ant-btn-compact-item-rtl:not(.ant-btn-compact-last-item) {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.ant-btn-compact-item-rtl.ant-btn-compact-last-item.ant-btn-compact-item-rtl:not(.ant-btn-compact-first-item) {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-.ant-btn-compact-item-rtl.ant-btn-sm.ant-btn-compact-first-item.ant-btn-compact-item-rtl.ant-btn-sm:not(.ant-btn-compact-last-item) {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.ant-btn-compact-item-rtl.ant-btn-sm.ant-btn-compact-last-item.ant-btn-compact-item-rtl.ant-btn-sm:not(.ant-btn-compact-first-item) {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-.ant-btn-compact-item-rtl.ant-btn-primary:not([disabled]) + .ant-btn-compact-item-rtl.ant-btn-primary:not([disabled])::after {
-  right: -1px;
-}
-.ant-btn-compact-vertical-item:not(.ant-btn-compact-vertical-last-item) {
-  margin-bottom: -1px;
-}
-.ant-btn-compact-vertical-item:hover,
-.ant-btn-compact-vertical-item:focus,
-.ant-btn-compact-vertical-item:active {
-  z-index: 2;
-}
-.ant-btn-compact-vertical-item[disabled] {
-  z-index: 0;
-}
-.ant-btn-compact-vertical-item:not(.ant-btn-compact-vertical-first-item):not(.ant-btn-compact-vertical-last-item) {
-  border-radius: 0;
-}
-.ant-btn-compact-vertical-item.ant-btn-compact-vertical-first-item:not(.ant-btn-compact-vertical-last-item) {
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.ant-btn-compact-vertical-item.ant-btn-compact-vertical-last-item:not(.ant-btn-compact-vertical-first-item) {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-}
-.ant-btn-compact-vertical-item.ant-btn-primary:not([disabled]) + .ant-btn-compact-vertical-item.ant-btn-primary:not([disabled]) {
-  position: relative;
-}
-.ant-btn-compact-vertical-item.ant-btn-primary:not([disabled]) + .ant-btn-compact-vertical-item.ant-btn-primary:not([disabled])::after {
-  position: absolute;
-  top: -1px;
-  left: -1px;
-  display: inline-block;
-  width: calc(100% + 1px * 2);
-  height: 1px;
-  background-color: #1c81b0;
-  content: ' ';
-}
 .ant-btn-rtl {
   direction: rtl;
 }
@@ -4627,7 +4516,6 @@ a.ant-btn-sm {
   padding-left: 16px;
 }
 .ant-card-meta-detail {
-  flex: 1;
   overflow: hidden;
 }
 .ant-card-meta-detail > div:not(:last-child) {
@@ -4820,7 +4708,6 @@ a.ant-btn-sm {
   display: flex !important;
   justify-content: center;
   margin-right: 15%;
-  margin-bottom: 0;
   margin-left: 15%;
   padding-left: 0;
   list-style: none;
@@ -4839,7 +4726,9 @@ a.ant-btn-sm {
   box-sizing: content-box;
   width: 16px;
   height: 3px;
-  margin: 0 4px;
+  margin: 0 2px;
+  margin-right: 3px;
+  margin-left: 3px;
   padding: 0;
   text-align: center;
   text-indent: -999px;
@@ -4847,7 +4736,6 @@ a.ant-btn-sm {
   transition: all 0.5s;
 }
 .ant-carousel .slick-dots li button {
-  position: relative;
   display: block;
   width: 100%;
   height: 3px;
@@ -4865,14 +4753,6 @@ a.ant-btn-sm {
 .ant-carousel .slick-dots li button:hover,
 .ant-carousel .slick-dots li button:focus {
   opacity: 0.75;
-}
-.ant-carousel .slick-dots li button::after {
-  position: absolute;
-  top: -4px;
-  right: -4px;
-  bottom: -4px;
-  left: -4px;
-  content: '';
 }
 .ant-carousel .slick-dots li.slick-active {
   width: 24px;
@@ -4905,7 +4785,7 @@ a.ant-btn-sm {
 .ant-carousel-vertical .slick-dots li {
   width: 3px;
   height: 16px;
-  margin: 4px 0;
+  margin: 4px 2px;
   vertical-align: baseline;
 }
 .ant-carousel-vertical .slick-dots li button {
@@ -5245,39 +5125,6 @@ a.ant-btn-sm {
 .ant-cascader-menu-item-keyword {
   color: #a8071a;
 }
-.ant-cascader-compact-item:not(.ant-cascader-compact-last-item):not(.ant-cascader-compact-item-rtl) {
-  margin-right: -1px;
-}
-.ant-cascader-compact-item:not(.ant-cascader-compact-last-item).ant-cascader-compact-item-rtl {
-  margin-left: -1px;
-}
-.ant-cascader-compact-item:hover,
-.ant-cascader-compact-item:focus,
-.ant-cascader-compact-item:active {
-  z-index: 2;
-}
-.ant-cascader-compact-item[disabled] {
-  z-index: 0;
-}
-.ant-cascader-compact-item:not(.ant-cascader-compact-first-item):not(.ant-cascader-compact-last-item).ant-cascader {
-  border-radius: 0;
-}
-.ant-cascader-compact-item.ant-cascader.ant-cascader-compact-first-item:not(.ant-cascader-compact-last-item):not(.ant-cascader-compact-item-rtl) {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-.ant-cascader-compact-item.ant-cascader.ant-cascader-compact-last-item:not(.ant-cascader-compact-first-item):not(.ant-cascader-compact-item-rtl) {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.ant-cascader-compact-item.ant-cascader.ant-cascader-compact-item-rtl.ant-cascader-compact-first-item:not(.ant-cascader-compact-last-item) {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.ant-cascader-compact-item.ant-cascader.ant-cascader-compact-item-rtl.ant-cascader-compact-last-item:not(.ant-cascader-compact-first-item) {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
 .ant-cascader-rtl .ant-cascader-menu-item-expand-icon,
 .ant-cascader-rtl .ant-cascader-menu-item-loading-icon {
   margin-right: 4px;
@@ -5541,9 +5388,6 @@ a.ant-btn-sm {
 .ant-collapse > .ant-collapse-item > .ant-collapse-header .ant-collapse-arrow svg {
   transition: transform 0.24s;
 }
-.ant-collapse > .ant-collapse-item > .ant-collapse-header .ant-collapse-header-text {
-  flex: auto;
-}
 .ant-collapse > .ant-collapse-item > .ant-collapse-header .ant-collapse-extra {
   margin-left: auto;
 }
@@ -5554,13 +5398,6 @@ a.ant-btn-sm {
   cursor: default;
 }
 .ant-collapse > .ant-collapse-item .ant-collapse-header-collapsible-only .ant-collapse-header-text {
-  flex: none;
-  cursor: pointer;
-}
-.ant-collapse > .ant-collapse-item .ant-collapse-icon-collapsible-only {
-  cursor: default;
-}
-.ant-collapse > .ant-collapse-item .ant-collapse-icon-collapsible-only .ant-collapse-expand-icon {
   cursor: pointer;
 }
 .ant-collapse > .ant-collapse-item.ant-collapse-no-arrow > .ant-collapse-header {
@@ -6149,6 +5986,7 @@ textarea.ant-picker-input > input {
 .ant-picker-range-arrow {
   position: absolute;
   z-index: 1;
+  display: none;
   width: 11.3137085px;
   height: 11.3137085px;
   margin-left: 16.5px;
@@ -6195,42 +6033,6 @@ textarea.ant-picker-input > input {
 }
 .ant-picker-panel-container .ant-picker-panel-focused {
   border-color: #e1e8ef;
-}
-.ant-picker-compact-item:not(.ant-picker-compact-last-item):not(.ant-picker-compact-item-rtl) {
-  margin-right: -1px;
-}
-.ant-picker-compact-item:not(.ant-picker-compact-last-item).ant-picker-compact-item-rtl {
-  margin-left: -1px;
-}
-.ant-picker-compact-item:hover,
-.ant-picker-compact-item:focus,
-.ant-picker-compact-item:active {
-  z-index: 2;
-}
-.ant-picker-compact-item.ant-picker-focused {
-  z-index: 2;
-}
-.ant-picker-compact-item[disabled] {
-  z-index: 0;
-}
-.ant-picker-compact-item:not(.ant-picker-compact-first-item):not(.ant-picker-compact-last-item).ant-picker {
-  border-radius: 0;
-}
-.ant-picker-compact-item.ant-picker.ant-picker-compact-first-item:not(.ant-picker-compact-last-item):not(.ant-picker-compact-item-rtl) {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-.ant-picker-compact-item.ant-picker.ant-picker-compact-last-item:not(.ant-picker-compact-first-item):not(.ant-picker-compact-item-rtl) {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.ant-picker-compact-item.ant-picker.ant-picker-compact-item-rtl.ant-picker-compact-first-item:not(.ant-picker-compact-last-item) {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.ant-picker-compact-item.ant-picker.ant-picker-compact-item-rtl.ant-picker-compact-last-item:not(.ant-picker-compact-first-item) {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
 }
 .ant-picker-panel {
   display: inline-flex;
@@ -7033,7 +6835,6 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
 }
 .ant-divider-horizontal.ant-divider-with-text {
   display: flex;
-  align-items: center;
   margin: 16px 0;
   color: #0a5085;
   font-weight: 500;
@@ -7046,6 +6847,7 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
 .ant-divider-horizontal.ant-divider-with-text::before,
 .ant-divider-horizontal.ant-divider-with-text::after {
   position: relative;
+  top: 50%;
   width: 50%;
   border-top: 1px solid transparent;
   border-top-color: inherit;
@@ -7054,15 +6856,19 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
   content: '';
 }
 .ant-divider-horizontal.ant-divider-with-text-left::before {
+  top: 50%;
   width: 5%;
 }
 .ant-divider-horizontal.ant-divider-with-text-left::after {
+  top: 50%;
   width: 95%;
 }
 .ant-divider-horizontal.ant-divider-with-text-right::before {
+  top: 50%;
   width: 95%;
 }
 .ant-divider-horizontal.ant-divider-with-text-right::after {
+  top: 50%;
   width: 5%;
 }
 .ant-divider-inner-text {
@@ -7122,70 +6928,72 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
 }
 .ant-drawer {
   position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
   z-index: 1000;
   pointer-events: none;
+  inset: 0;
 }
 .ant-drawer-inline {
   position: absolute;
 }
 .ant-drawer-mask {
   position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
   z-index: 1000;
   background: rgba(0, 0, 0, 0.45);
   pointer-events: auto;
+  inset: 0;
 }
 .ant-drawer-content-wrapper {
   position: absolute;
   z-index: 1000;
-  transition: all 0.3s;
+  transition: transform 0.3s;
 }
-.ant-drawer-content-wrapper-hidden {
-  display: none;
-}
-.ant-drawer-left > .ant-drawer-content-wrapper {
+.ant-drawer-left .ant-drawer-content-wrapper {
   top: 0;
   bottom: 0;
   left: 0;
-  box-shadow: 6px 0 16px -8px rgba(54, 74, 99, 0.08), 9px 0 28px 0 rgba(54, 74, 99, 0.05);
 }
-.ant-drawer-right > .ant-drawer-content-wrapper {
+.ant-drawer-right .ant-drawer-content-wrapper {
   top: 0;
   right: 0;
   bottom: 0;
-  box-shadow: -6px 0 16px -8px rgba(54, 74, 99, 0.08), -9px 0 28px 0 rgba(54, 74, 99, 0.05);
 }
-.ant-drawer-top > .ant-drawer-content-wrapper {
+.ant-drawer-top .ant-drawer-content-wrapper {
   top: 0;
   right: 0;
   left: 0;
-  box-shadow: 0 6px 16px -8px rgba(54, 74, 99, 0.08), 0 9px 28px 0 rgba(54, 74, 99, 0.05);
 }
-.ant-drawer-bottom > .ant-drawer-content-wrapper {
+.ant-drawer-bottom .ant-drawer-content-wrapper {
   right: 0;
   bottom: 0;
   left: 0;
-  box-shadow: 0 -6px 16px -8px rgba(54, 74, 99, 0.08), 0 -9px 28px 0 rgba(54, 74, 99, 0.05);
 }
 .ant-drawer-content {
   width: 100%;
   height: 100%;
   overflow: auto;
-  background: #fff;
   pointer-events: auto;
+}
+.ant-drawer-content-hidden {
+  display: none;
+}
+.ant-drawer-left .ant-drawer-content {
+  box-shadow: 6px 0 16px -8px rgba(54, 74, 99, 0.08), 9px 0 28px 0 rgba(54, 74, 99, 0.05);
+}
+.ant-drawer-right .ant-drawer-content {
+  box-shadow: -6px 0 16px -8px rgba(54, 74, 99, 0.08), -9px 0 28px 0 rgba(54, 74, 99, 0.05);
+}
+.ant-drawer-top .ant-drawer-content {
+  box-shadow: 0 6px 16px -8px rgba(54, 74, 99, 0.08), 0 9px 28px 0 rgba(54, 74, 99, 0.05);
+}
+.ant-drawer-bottom .ant-drawer-content {
+  box-shadow: 0 -6px 16px -8px rgba(54, 74, 99, 0.08), 0 -9px 28px 0 rgba(54, 74, 99, 0.05);
 }
 .ant-drawer-wrapper-body {
   display: flex;
   flex-direction: column;
   width: 100%;
   height: 100%;
+  background: #fff;
 }
 .ant-drawer-header {
   display: flex;
@@ -7204,7 +7012,7 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
   min-height: 0;
 }
 .ant-drawer-extra {
-  flex: none;
+  flex: 0;
 }
 .ant-drawer-close {
   display: inline-block;
@@ -7249,11 +7057,6 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
   padding: 16px 24px;
   border-top: 1px solid #e1e8ef;
 }
-.panel-motion-enter-start,
-.panel-motion-appear-start,
-.panel-motion-leave-start {
-  transition: none;
-}
 .panel-motion-enter-active,
 .panel-motion-appear-active,
 .panel-motion-leave-active {
@@ -7278,19 +7081,14 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
 .ant-drawer-mask-motion-leave-active {
   opacity: 0;
 }
-.ant-drawer-panel-motion-left-enter-start,
-.ant-drawer-panel-motion-left-appear-start,
-.ant-drawer-panel-motion-left-leave-start {
-  transition: none;
-}
 .ant-drawer-panel-motion-left-enter-active,
 .ant-drawer-panel-motion-left-appear-active,
 .ant-drawer-panel-motion-left-leave-active {
   transition: all 0.3s;
 }
-.ant-drawer-panel-motion-left-enter-start,
-.ant-drawer-panel-motion-left-appear-start {
-  transform: translateX(-100%) !important;
+.ant-drawer-panel-motion-left-enter,
+.ant-drawer-panel-motion-left-appear {
+  transform: translateX(-100%);
 }
 .ant-drawer-panel-motion-left-enter-active,
 .ant-drawer-panel-motion-left-appear-active {
@@ -7302,19 +7100,14 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
 .ant-drawer-panel-motion-left-leave-active {
   transform: translateX(-100%);
 }
-.ant-drawer-panel-motion-right-enter-start,
-.ant-drawer-panel-motion-right-appear-start,
-.ant-drawer-panel-motion-right-leave-start {
-  transition: none;
-}
 .ant-drawer-panel-motion-right-enter-active,
 .ant-drawer-panel-motion-right-appear-active,
 .ant-drawer-panel-motion-right-leave-active {
   transition: all 0.3s;
 }
-.ant-drawer-panel-motion-right-enter-start,
-.ant-drawer-panel-motion-right-appear-start {
-  transform: translateX(100%) !important;
+.ant-drawer-panel-motion-right-enter,
+.ant-drawer-panel-motion-right-appear {
+  transform: translateX(100%);
 }
 .ant-drawer-panel-motion-right-enter-active,
 .ant-drawer-panel-motion-right-appear-active {
@@ -7326,19 +7119,14 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
 .ant-drawer-panel-motion-right-leave-active {
   transform: translateX(100%);
 }
-.ant-drawer-panel-motion-top-enter-start,
-.ant-drawer-panel-motion-top-appear-start,
-.ant-drawer-panel-motion-top-leave-start {
-  transition: none;
-}
 .ant-drawer-panel-motion-top-enter-active,
 .ant-drawer-panel-motion-top-appear-active,
 .ant-drawer-panel-motion-top-leave-active {
   transition: all 0.3s;
 }
-.ant-drawer-panel-motion-top-enter-start,
-.ant-drawer-panel-motion-top-appear-start {
-  transform: translateY(-100%) !important;
+.ant-drawer-panel-motion-top-enter,
+.ant-drawer-panel-motion-top-appear {
+  transform: translateY(-100%);
 }
 .ant-drawer-panel-motion-top-enter-active,
 .ant-drawer-panel-motion-top-appear-active {
@@ -7350,19 +7138,14 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
 .ant-drawer-panel-motion-top-leave-active {
   transform: translateY(-100%);
 }
-.ant-drawer-panel-motion-bottom-enter-start,
-.ant-drawer-panel-motion-bottom-appear-start,
-.ant-drawer-panel-motion-bottom-leave-start {
-  transition: none;
-}
 .ant-drawer-panel-motion-bottom-enter-active,
 .ant-drawer-panel-motion-bottom-appear-active,
 .ant-drawer-panel-motion-bottom-leave-active {
   transition: all 0.3s;
 }
-.ant-drawer-panel-motion-bottom-enter-start,
-.ant-drawer-panel-motion-bottom-appear-start {
-  transform: translateY(100%) !important;
+.ant-drawer-panel-motion-bottom-enter,
+.ant-drawer-panel-motion-bottom-appear {
+  transform: translateY(100%);
 }
 .ant-drawer-panel-motion-bottom-enter-active,
 .ant-drawer-panel-motion-bottom-appear-active {
@@ -7582,25 +7365,19 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
 .ant-dropdown-menu-submenu-title.ant-dropdown-menu-submenu-title-active {
   background-color: #f1f5f9;
 }
-.ant-dropdown-menu-item.ant-dropdown-menu-item-disabled,
-.ant-dropdown-menu-item.ant-dropdown-menu-submenu-title-disabled,
-.ant-dropdown-menu-submenu-title.ant-dropdown-menu-item-disabled,
-.ant-dropdown-menu-submenu-title.ant-dropdown-menu-submenu-title-disabled {
+.ant-dropdown-menu-item-disabled,
+.ant-dropdown-menu-submenu-title-disabled {
   color: #8b9db2;
   cursor: not-allowed;
 }
-.ant-dropdown-menu-item.ant-dropdown-menu-item-disabled:hover,
-.ant-dropdown-menu-item.ant-dropdown-menu-submenu-title-disabled:hover,
-.ant-dropdown-menu-submenu-title.ant-dropdown-menu-item-disabled:hover,
-.ant-dropdown-menu-submenu-title.ant-dropdown-menu-submenu-title-disabled:hover {
+.ant-dropdown-menu-item-disabled:hover,
+.ant-dropdown-menu-submenu-title-disabled:hover {
   color: #8b9db2;
   background-color: #fff;
   cursor: not-allowed;
 }
-.ant-dropdown-menu-item.ant-dropdown-menu-item-disabled a,
-.ant-dropdown-menu-item.ant-dropdown-menu-submenu-title-disabled a,
-.ant-dropdown-menu-submenu-title.ant-dropdown-menu-item-disabled a,
-.ant-dropdown-menu-submenu-title.ant-dropdown-menu-submenu-title-disabled a {
+.ant-dropdown-menu-item-disabled a,
+.ant-dropdown-menu-submenu-title-disabled a {
   pointer-events: none;
 }
 .ant-dropdown-menu-item-divider,
@@ -7890,7 +7667,7 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
 .ant-form-horizontal .ant-form-item-label[class*='-24 '] + .ant-form-item-control {
   min-width: unset;
 }
-.ant-form-vertical .ant-form-item-row {
+.ant-form-vertical .ant-form-item {
   flex-direction: column;
 }
 .ant-form-vertical .ant-form-item-label > label {
@@ -8418,7 +8195,6 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
 .ant-row {
   display: flex;
   flex-flow: row wrap;
-  min-width: 0;
 }
 .ant-row::before,
 .ant-row::after {
@@ -13722,13 +13498,6 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
 .ant-image-preview-wrap {
   z-index: 1080;
 }
-.ant-image-preview-operations-wrapper {
-  position: fixed;
-  top: 0;
-  right: 0;
-  z-index: 1081;
-  width: 100%;
-}
 .ant-image-preview-operations {
   box-sizing: border-box;
   margin: 0;
@@ -13738,9 +13507,14 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
   font-variant: tabular-nums;
   line-height: 1.5715;
   font-feature-settings: 'tnum';
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
   display: flex;
   flex-direction: row-reverse;
   align-items: center;
+  width: 100%;
   color: #cfe6f2;
   list-style: none;
   background: rgba(0, 0, 0, 0.1);
@@ -13750,10 +13524,6 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
   margin-left: 12px;
   padding: 12px;
   cursor: pointer;
-  transition: all 0.3s;
-}
-.ant-image-preview-operations-operation:hover {
-  background: rgba(0, 0, 0, 0.2);
 }
 .ant-image-preview-operations-operation-disabled {
   color: rgba(207, 230, 242, 0.25);
@@ -13772,39 +13542,29 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
 }
 .ant-image-preview-switch-left,
 .ant-image-preview-switch-right {
-  position: fixed;
+  position: absolute;
   top: 50%;
-  right: 8px;
-  z-index: 1081;
+  right: 10px;
+  z-index: 1;
   display: flex;
   align-items: center;
   justify-content: center;
   width: 44px;
   height: 44px;
+  margin-top: -22px;
   color: #cfe6f2;
   background: rgba(0, 0, 0, 0.1);
   border-radius: 50%;
-  transform: translateY(-50%);
   cursor: pointer;
-  transition: all 0.3s;
   pointer-events: auto;
 }
-.ant-image-preview-switch-left:hover,
-.ant-image-preview-switch-right:hover {
-  background: rgba(0, 0, 0, 0.2);
-}
 .ant-image-preview-switch-left-disabled,
-.ant-image-preview-switch-right-disabled,
-.ant-image-preview-switch-left-disabled:hover,
-.ant-image-preview-switch-right-disabled:hover {
+.ant-image-preview-switch-right-disabled {
   color: rgba(207, 230, 242, 0.25);
-  background: rgba(0, 0, 0, 0.1);
   cursor: not-allowed;
 }
 .ant-image-preview-switch-left-disabled > .anticon,
-.ant-image-preview-switch-right-disabled > .anticon,
-.ant-image-preview-switch-left-disabled:hover > .anticon,
-.ant-image-preview-switch-right-disabled:hover > .anticon {
+.ant-image-preview-switch-right-disabled > .anticon {
   cursor: not-allowed;
 }
 .ant-image-preview-switch-left > .anticon,
@@ -13812,10 +13572,10 @@ _:-ms-fullscreen .ant-picker-range-wrapper .ant-picker-year-panel .ant-picker-ce
   font-size: 18px;
 }
 .ant-image-preview-switch-left {
-  left: 8px;
+  left: 10px;
 }
 .ant-image-preview-switch-right {
-  right: 8px;
+  right: 10px;
 }
 .ant-input-affix-wrapper {
   position: relative;
@@ -13929,21 +13689,17 @@ textarea.ant-input-affix-wrapper {
   z-index: 1;
 }
 .ant-input-affix-wrapper-disabled .ant-input[disabled] {
-  background: rgba(255, 255, 255, 0);
+  background: transparent;
 }
-.ant-input-affix-wrapper > .ant-input {
-  font-size: inherit;
+.ant-input-affix-wrapper > input.ant-input {
+  padding: 0;
   border: none;
   outline: none;
 }
-.ant-input-affix-wrapper > .ant-input:focus {
+.ant-input-affix-wrapper > input.ant-input:focus {
   box-shadow: none !important;
 }
-.ant-input-affix-wrapper > .ant-input:not(textarea) {
-  padding: 0;
-}
 .ant-input-affix-wrapper::before {
-  display: inline-block;
   width: 0;
   visibility: hidden;
   content: '\a0';
@@ -13995,10 +13751,11 @@ textarea.ant-input-affix-wrapper {
 .ant-input-clear-icon-has-suffix {
   margin: 0 4px;
 }
-.ant-input-affix-wrapper.ant-input-affix-wrapper-textarea-with-clear-btn {
-  padding: 0;
+.ant-input-affix-wrapper-textarea-with-clear-btn {
+  padding: 0 !important;
+  border: 0 !important;
 }
-.ant-input-affix-wrapper.ant-input-affix-wrapper-textarea-with-clear-btn .ant-input-clear-icon {
+.ant-input-affix-wrapper-textarea-with-clear-btn .ant-input-clear-icon {
   position: absolute;
   top: 8px;
   right: 8px;
@@ -14378,8 +14135,9 @@ textarea.ant-input {
   vertical-align: top;
   border-radius: 0;
 }
-.ant-input-group.ant-input-group-compact > .ant-input-affix-wrapper,
-.ant-input-group.ant-input-group-compact > .ant-input-number-affix-wrapper,
+.ant-input-group.ant-input-group-compact > .ant-input-affix-wrapper {
+  display: inline-flex;
+}
 .ant-input-group.ant-input-group-compact > .ant-picker-range {
   display: inline-flex;
 }
@@ -14558,39 +14316,6 @@ textarea.ant-input {
   align-items: center;
   margin: auto;
 }
-.ant-input-compact-item:not(.ant-input-compact-last-item):not(.ant-input-compact-item-rtl) {
-  margin-right: -1px;
-}
-.ant-input-compact-item:not(.ant-input-compact-last-item).ant-input-compact-item-rtl {
-  margin-left: -1px;
-}
-.ant-input-compact-item:hover,
-.ant-input-compact-item:focus,
-.ant-input-compact-item:active {
-  z-index: 2;
-}
-.ant-input-compact-item[disabled] {
-  z-index: 0;
-}
-.ant-input-compact-item:not(.ant-input-compact-first-item):not(.ant-input-compact-last-item).ant-input {
-  border-radius: 0;
-}
-.ant-input-compact-item.ant-input.ant-input-compact-first-item:not(.ant-input-compact-last-item):not(.ant-input-compact-item-rtl) {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-.ant-input-compact-item.ant-input.ant-input-compact-last-item:not(.ant-input-compact-first-item):not(.ant-input-compact-item-rtl) {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.ant-input-compact-item.ant-input.ant-input-compact-item-rtl.ant-input-compact-first-item:not(.ant-input-compact-last-item) {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.ant-input-compact-item.ant-input.ant-input-compact-item-rtl.ant-input-compact-last-item:not(.ant-input-compact-first-item) {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
 .ant-input-search .ant-input:hover,
 .ant-input-search .ant-input:focus {
   border-color: #1d8bc6;
@@ -14637,32 +14362,6 @@ textarea.ant-input {
 .ant-input-search-small .ant-input-search-button {
   height: 24px;
 }
-.ant-input-search.ant-input-compact-item:not(.ant-input-compact-item-rtl):not(.ant-input-compact-last-item) .ant-input-group-addon .ant-input-search-button {
-  margin-right: -1px;
-  border-radius: 0;
-}
-.ant-input-search.ant-input-compact-item:not(.ant-input-compact-first-item) .ant-input,
-.ant-input-search.ant-input-compact-item:not(.ant-input-compact-first-item) .ant-input-affix-wrapper {
-  border-radius: 0;
-}
-.ant-input-search.ant-input-compact-item > .ant-input-group-addon .ant-input-search-button:hover,
-.ant-input-search.ant-input-compact-item > .ant-input:hover,
-.ant-input-search.ant-input-compact-item .ant-input-affix-wrapper:hover,
-.ant-input-search.ant-input-compact-item > .ant-input-group-addon .ant-input-search-button:focus,
-.ant-input-search.ant-input-compact-item > .ant-input:focus,
-.ant-input-search.ant-input-compact-item .ant-input-affix-wrapper:focus,
-.ant-input-search.ant-input-compact-item > .ant-input-group-addon .ant-input-search-button:active,
-.ant-input-search.ant-input-compact-item > .ant-input:active,
-.ant-input-search.ant-input-compact-item .ant-input-affix-wrapper:active {
-  z-index: 2;
-}
-.ant-input-search.ant-input-compact-item > .ant-input-affix-wrapper-focused {
-  z-index: 2;
-}
-.ant-input-search.ant-input-compact-item-rtl:not(.ant-input-compact-last-item) .ant-input-group-addon:last-child .ant-input-search-button {
-  margin-left: -1px;
-  border-radius: 0;
-}
 .ant-input-group-wrapper-rtl {
   direction: rtl;
 }
@@ -14698,21 +14397,18 @@ textarea.ant-input {
 }
 .ant-input-search-rtl .ant-input:hover + .ant-input-group-addon .ant-input-search-button:not(.ant-btn-primary),
 .ant-input-search-rtl .ant-input:focus + .ant-input-group-addon .ant-input-search-button:not(.ant-btn-primary) {
+  border-right-color: #1d8bc6;
   border-left-color: #b3c2d3;
-}
-.ant-input-search-rtl .ant-input:hover + .ant-input-group-addon .ant-input-search-button:not(.ant-btn-primary):hover,
-.ant-input-search-rtl .ant-input:focus + .ant-input-group-addon .ant-input-search-button:not(.ant-btn-primary):hover {
-  border-left-color: #1d8bc6;
 }
 .ant-input-search-rtl > .ant-input-group > .ant-input-affix-wrapper:hover,
 .ant-input-search-rtl > .ant-input-group > .ant-input-affix-wrapper-focused {
   border-right-color: #1d8bc6;
 }
-.ant-input-search-rtl > .ant-input-group > .ant-input-group-addon:last-child {
+.ant-input-search-rtl > .ant-input-group > .ant-input-group-addon {
   right: -1px;
   left: auto;
 }
-.ant-input-search-rtl > .ant-input-group > .ant-input-group-addon:last-child .ant-input-search-button {
+.ant-input-search-rtl > .ant-input-group > .ant-input-group-addon .ant-input-search-button {
   border-radius: 2px 0 0 2px;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
@@ -14855,7 +14551,6 @@ textarea.ant-input-number-affix-wrapper {
   padding: 0;
 }
 .ant-input-number-affix-wrapper::before {
-  display: inline-block;
   width: 0;
   visibility: hidden;
   content: '\a0';
@@ -15254,8 +14949,9 @@ textarea.ant-input-number {
   vertical-align: top;
   border-radius: 0;
 }
-.ant-input-number-group.ant-input-number-group-compact > .ant-input-number-affix-wrapper,
-.ant-input-number-group.ant-input-number-group-compact > .ant-input-number-number-affix-wrapper,
+.ant-input-number-group.ant-input-number-group-compact > .ant-input-number-affix-wrapper {
+  display: inline-flex;
+}
 .ant-input-number-group.ant-input-number-group-compact > .ant-picker-range {
   display: inline-flex;
 }
@@ -15588,10 +15284,6 @@ textarea.ant-input-number {
 .ant-input-number-borderless .ant-input-number-handler-down {
   border-top-width: 0;
 }
-.ant-input-number:hover:not(.ant-input-number-borderless) .ant-input-number-handler-down,
-.ant-input-number-focused:not(.ant-input-number-borderless) .ant-input-number-handler-down {
-  border-top: 1px solid #b3c2d3;
-}
 .ant-input-number-handler-up-disabled,
 .ant-input-number-handler-down-disabled {
   cursor: not-allowed;
@@ -15605,42 +15297,6 @@ textarea.ant-input-number {
 }
 .ant-input-number-out-of-range input {
   color: #a8071a;
-}
-.ant-input-number-compact-item:not(.ant-input-number-compact-last-item):not(.ant-input-number-compact-item-rtl) {
-  margin-right: -1px;
-}
-.ant-input-number-compact-item:not(.ant-input-number-compact-last-item).ant-input-number-compact-item-rtl {
-  margin-left: -1px;
-}
-.ant-input-number-compact-item:hover,
-.ant-input-number-compact-item:focus,
-.ant-input-number-compact-item:active {
-  z-index: 2;
-}
-.ant-input-number-compact-item.ant-input-number-focused {
-  z-index: 2;
-}
-.ant-input-number-compact-item[disabled] {
-  z-index: 0;
-}
-.ant-input-number-compact-item:not(.ant-input-number-compact-first-item):not(.ant-input-number-compact-last-item).ant-input-number {
-  border-radius: 0;
-}
-.ant-input-number-compact-item.ant-input-number.ant-input-number-compact-first-item:not(.ant-input-number-compact-last-item):not(.ant-input-number-compact-item-rtl) {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-.ant-input-number-compact-item.ant-input-number.ant-input-number-compact-last-item:not(.ant-input-number-compact-first-item):not(.ant-input-number-compact-item-rtl) {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.ant-input-number-compact-item.ant-input-number.ant-input-number-compact-item-rtl.ant-input-number-compact-first-item:not(.ant-input-number-compact-last-item) {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.ant-input-number-compact-item.ant-input-number.ant-input-number-compact-item-rtl.ant-input-number-compact-last-item:not(.ant-input-number-compact-first-item) {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
 }
 .ant-input-number-rtl {
   direction: rtl;
@@ -16650,8 +16306,8 @@ textarea.ant-mentions {
 .ant-menu-submenu-title.ant-menu-item-only-child > .ant-menu-item-icon {
   margin-right: 0;
 }
-.ant-menu-item:not(.ant-menu-item-disabled):focus-visible,
-.ant-menu-submenu-title:not(.ant-menu-item-disabled):focus-visible {
+.ant-menu-item:focus-visible,
+.ant-menu-submenu-title:focus-visible {
   box-shadow: 0 0 0 2px #89c5d6;
 }
 .ant-menu > .ant-menu-item-divider {
@@ -17614,9 +17270,6 @@ textarea.ant-mentions {
 .ant-modal-confirm-success .ant-modal-confirm-body > .anticon {
   color: #389e0d;
 }
-.ant-modal-confirm .ant-zoom-leave .ant-modal-confirm-btns {
-  pointer-events: none;
-}
 .ant-modal-wrap-rtl {
   direction: rtl;
 }
@@ -17925,12 +17578,13 @@ textarea.ant-mentions {
 }
 .ant-page-header-back-button {
   color: #006aa3;
+  text-decoration: none;
   outline: none;
-  cursor: pointer;
   transition: color 0.3s;
   color: #000;
+  cursor: pointer;
 }
-.ant-page-header-back-button:focus-visible,
+.ant-page-header-back-button:focus,
 .ant-page-header-back-button:hover {
   color: #006aa3;
 }
@@ -18595,7 +18249,6 @@ textarea.ant-pagination-options-quick-jumper input {
   top: 0;
   left: 0;
   z-index: 1030;
-  max-width: 100vw;
   font-weight: normal;
   white-space: normal;
   text-align: left;
@@ -18638,6 +18291,7 @@ textarea.ant-pagination-options-quick-jumper input {
   background-clip: padding-box;
   border-radius: 2px;
   box-shadow: 0 3px 6px -4px rgba(54, 74, 99, 0.3), 0 6px 16px 0 rgba(54, 74, 99, 0.16);
+  box-shadow: 0 0 8px rgba(54, 74, 99, 0.15) \9;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
   .ant-popover {
@@ -18657,28 +18311,29 @@ textarea.ant-pagination-options-quick-jumper input {
   border-bottom: 1px solid #e1e8ef;
 }
 .ant-popover-inner-content {
-  width: max-content;
-  max-width: 100%;
   padding: 12px 16px;
   color: #364a63;
 }
 .ant-popover-message {
-  display: flex;
+  position: relative;
   padding: 4px 0 12px;
   color: #364a63;
   font-size: 14px;
 }
-.ant-popover-message-icon {
-  display: inline-block;
-  margin-right: 8px;
+.ant-popover-message > .anticon {
+  position: absolute;
+  top: 8.0005px;
   color: #faad14;
   font-size: 14px;
+}
+.ant-popover-message-title {
+  padding-left: 22px;
 }
 .ant-popover-buttons {
   margin-bottom: 4px;
   text-align: right;
 }
-.ant-popover-buttons button:not(:first-child) {
+.ant-popover-buttons button {
   margin-left: 8px;
 }
 .ant-popover-arrow {
@@ -18889,11 +18544,8 @@ textarea.ant-pagination-options-quick-jumper input {
   direction: rtl;
   text-align: right;
 }
-.ant-popover-rtl .ant-popover-message-icon {
-  margin-right: 0;
-  margin-left: 8px;
-}
 .ant-popover-rtl .ant-popover-message-title {
+  padding-right: 22px;
   padding-left: 16px;
 }
 .ant-popover-rtl .ant-popover-buttons {
@@ -19730,7 +19382,7 @@ span.ant-radio + * {
 .ant-select-single .ant-select-selector .ant-select-selection-placeholder {
   padding: 0;
   line-height: 30px;
-  transition: all 0.3s, visibility 0s;
+  transition: all 0.3s;
 }
 .ant-select-single .ant-select-selector .ant-select-selection-item {
   position: relative;
@@ -19858,7 +19510,6 @@ span.ant-radio + * {
   width: 0;
   margin: 2px 0;
   line-height: 24px;
-  visibility: hidden;
   content: '\a0';
 }
 .ant-select-multiple.ant-select-show-arrow .ant-select-selector,
@@ -20012,23 +19663,23 @@ span.ant-radio + * {
 .ant-select-disabled .ant-select-selection-item-remove {
   display: none;
 }
-.ant-select-status-error.ant-select:not(.ant-select-disabled):not(.ant-select-customize-input):not(.ant-pagination-size-changer) .ant-select-selector {
+.ant-select-status-error.ant-select:not(.ant-select-disabled):not(.ant-select-customize-input) .ant-select-selector {
   background-color: #fff;
   border-color: #a8071a !important;
 }
-.ant-select-status-error.ant-select:not(.ant-select-disabled):not(.ant-select-customize-input):not(.ant-pagination-size-changer).ant-select-open .ant-select-selector,
-.ant-select-status-error.ant-select:not(.ant-select-disabled):not(.ant-select-customize-input):not(.ant-pagination-size-changer).ant-select-focused .ant-select-selector {
+.ant-select-status-error.ant-select:not(.ant-select-disabled):not(.ant-select-customize-input).ant-select-open .ant-select-selector,
+.ant-select-status-error.ant-select:not(.ant-select-disabled):not(.ant-select-customize-input).ant-select-focused .ant-select-selector {
   border-color: #b52430;
   box-shadow: 0 0 0 1px rgba(168, 7, 26, 0.2);
   border-right-width: 1px;
   outline: 0;
 }
-.ant-select-status-warning.ant-select:not(.ant-select-disabled):not(.ant-select-customize-input):not(.ant-pagination-size-changer) .ant-select-selector {
+.ant-select-status-warning.ant-select:not(.ant-select-disabled):not(.ant-select-customize-input) .ant-select-selector {
   background-color: #fff;
   border-color: #faad14 !important;
 }
-.ant-select-status-warning.ant-select:not(.ant-select-disabled):not(.ant-select-customize-input):not(.ant-pagination-size-changer).ant-select-open .ant-select-selector,
-.ant-select-status-warning.ant-select:not(.ant-select-disabled):not(.ant-select-customize-input):not(.ant-pagination-size-changer).ant-select-focused .ant-select-selector {
+.ant-select-status-warning.ant-select:not(.ant-select-disabled):not(.ant-select-customize-input).ant-select-open .ant-select-selector,
+.ant-select-status-warning.ant-select:not(.ant-select-disabled):not(.ant-select-customize-input).ant-select-focused .ant-select-selector {
   border-color: #ffc53d;
   box-shadow: 0 0 0 1px rgba(250, 173, 20, 0.2);
   border-right-width: 1px;
@@ -20340,43 +19991,6 @@ span.ant-radio + * {
 }
 .ant-select.ant-select-in-form-item {
   width: 100%;
-}
-.ant-select-compact-item:not(.ant-select-compact-last-item) {
-  margin-right: -1px;
-}
-.ant-select-compact-item:not(.ant-select-compact-last-item).ant-select-compact-item-rtl {
-  margin-right: 0;
-  margin-left: -1px;
-}
-.ant-select-compact-item:hover > *,
-.ant-select-compact-item:focus > *,
-.ant-select-compact-item:active > * {
-  z-index: 2;
-}
-.ant-select-compact-item.ant-select-focused > * {
-  z-index: 2;
-}
-.ant-select-compact-item[disabled] > * {
-  z-index: 0;
-}
-.ant-select-compact-item:not(.ant-select-compact-first-item):not(.ant-select-compact-last-item).ant-select > .ant-select-selector {
-  border-radius: 0;
-}
-.ant-select-compact-item.ant-select-compact-first-item.ant-select:not(.ant-select-compact-last-item):not(.ant-select-compact-item-rtl) > .ant-select-selector {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-.ant-select-compact-item.ant-select-compact-last-item.ant-select:not(.ant-select-compact-first-item):not(.ant-select-compact-item-rtl) > .ant-select-selector {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.ant-select-compact-item.ant-select.ant-select-compact-first-item.ant-select-compact-item-rtl:not(.ant-select-compact-last-item) > .ant-select-selector {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.ant-select-compact-item.ant-select.ant-select-compact-last-item.ant-select-compact-item-rtl:not(.ant-select-compact-first-item) > .ant-select-selector {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
 }
 .ant-select-rtl {
   direction: rtl;
@@ -20937,20 +20551,7 @@ span.ant-radio + * {
 .ant-space-item:empty {
   display: none;
 }
-.ant-space-compact {
-  display: inline-flex;
-}
-.ant-space-compact-block {
-  display: flex;
-  width: 100%;
-}
-.ant-space-compact-vertical {
-  flex-direction: column;
-}
 .ant-space-rtl {
-  direction: rtl;
-}
-.ant-space-compact-rtl {
   direction: rtl;
 }
 .ant-spin {
@@ -20966,7 +20567,6 @@ span.ant-radio + * {
   position: absolute;
   display: none;
   color: #006aa3;
-  font-size: 0;
   text-align: center;
   vertical-align: middle;
   opacity: 0;
@@ -21001,7 +20601,6 @@ span.ant-radio + * {
   top: 50%;
   width: 100%;
   padding-top: 5px;
-  font-size: 14px;
   text-shadow: 0 1px 2px #fff;
 }
 .ant-spin-nested-loading > div > .ant-spin.ant-spin-show-text .ant-spin-dot {
@@ -21526,7 +21125,7 @@ span.ant-radio + * {
 .ant-steps-vertical > .ant-steps-item > .ant-steps-item-container > .ant-steps-item-tail {
   position: absolute;
   top: 0;
-  left: 15px;
+  left: 16px;
   width: 1px;
   height: 100%;
   padding: 38px 0 6px;
@@ -21544,7 +21143,7 @@ span.ant-radio + * {
 .ant-steps-vertical.ant-steps-small .ant-steps-item-container .ant-steps-item-tail {
   position: absolute;
   top: 0;
-  left: 11px;
+  left: 12px;
   padding: 30px 0 6px;
 }
 .ant-steps-vertical.ant-steps-small .ant-steps-item-container .ant-steps-item-title {
@@ -21915,15 +21514,6 @@ span.ant-radio + * {
   right: -2px;
   left: auto;
 }
-.ant-steps-rtl.ant-steps-with-progress.ant-steps-vertical > .ant-steps-item {
-  padding-right: 4px;
-}
-.ant-steps-rtl.ant-steps-with-progress.ant-steps-vertical > .ant-steps-item > .ant-steps-item-container > .ant-steps-item-tail {
-  right: 19px;
-}
-.ant-steps-rtl.ant-steps-with-progress.ant-steps-small.ant-steps-vertical > .ant-steps-item > .ant-steps-item-container > .ant-steps-item-tail {
-  right: 15px;
-}
 .ant-steps-rtl.ant-steps-with-progress.ant-steps-horizontal.ant-steps-label-horizontal .ant-steps-item:first-child {
   padding-right: 4px;
   padding-left: 0;
@@ -21934,23 +21524,12 @@ span.ant-radio + * {
 .ant-steps-with-progress .ant-steps-item {
   padding-top: 4px;
 }
-.ant-steps-with-progress .ant-steps-item > .ant-steps-item-container > .ant-steps-item-tail {
-  top: 4px;
-  left: 19px;
+.ant-steps-with-progress .ant-steps-item .ant-steps-item-tail {
+  top: 4px !important;
 }
-.ant-steps-with-progress.ant-steps-horizontal .ant-steps-item:first-child,
-.ant-steps-with-progress.ant-steps-small.ant-steps-horizontal .ant-steps-item:first-child {
+.ant-steps-with-progress.ant-steps-horizontal .ant-steps-item:first-child {
   padding-bottom: 4px;
   padding-left: 4px;
-}
-.ant-steps-with-progress.ant-steps-small > .ant-steps-item > .ant-steps-item-container > .ant-steps-item-tail {
-  left: 15px;
-}
-.ant-steps-with-progress.ant-steps-vertical .ant-steps-item {
-  padding-left: 4px;
-}
-.ant-steps-with-progress.ant-steps-label-vertical .ant-steps-item .ant-steps-item-tail {
-  top: 14px !important;
 }
 .ant-steps-with-progress .ant-steps-item-icon {
   position: relative;
@@ -21978,7 +21557,7 @@ span.ant-radio + * {
   height: 22px;
   line-height: 22px;
   vertical-align: middle;
-  background-color: #8b9db2;
+  background-image: linear-gradient(to right, #8b9db2, #8b9db2), linear-gradient(to right, #fff, #fff);
   border: 0;
   border-radius: 100px;
   cursor: pointer;
@@ -21996,7 +21575,7 @@ span.ant-radio + * {
   box-shadow: none;
 }
 .ant-switch-checked {
-  background-color: #006aa3;
+  background: #006aa3;
 }
 .ant-switch-loading,
 .ant-switch-disabled {
@@ -22642,7 +22221,7 @@ table tr th.ant-table-selection-column::after {
 }
 .ant-table-row-expand-icon {
   color: #006aa3;
-  outline: none;
+  text-decoration: none;
   cursor: pointer;
   transition: color 0.3s;
   position: relative;
@@ -22656,11 +22235,12 @@ table tr th.ant-table-selection-column::after {
   background: #fff;
   border: 1px solid #e1e8ef;
   border-radius: 2px;
+  outline: none;
   transform: scale(0.94117647);
   transition: all 0.3s;
   user-select: none;
 }
-.ant-table-row-expand-icon:focus-visible,
+.ant-table-row-expand-icon:focus,
 .ant-table-row-expand-icon:hover {
   color: #006aa3;
 }
@@ -22775,7 +22355,7 @@ tr.ant-table-expanded-row .ant-descriptions-view table {
   position: absolute;
   top: 0;
   bottom: 0;
-  z-index: calc(calc(2 + 1) + 1);
+  z-index: 2;
   width: 30px;
   transition: box-shadow 0.3s;
   content: '';
@@ -23538,7 +23118,7 @@ tr.ant-table-expanded-row .ant-descriptions-view table {
   margin: 0 0 0 32px;
 }
 .ant-tabs-content {
-  position: relative;
+  display: flex;
   width: 100%;
 }
 .ant-tabs-content-holder {
@@ -23546,36 +23126,13 @@ tr.ant-table-expanded-row .ant-descriptions-view table {
   min-width: 0;
   min-height: 0;
 }
+.ant-tabs-content-animated {
+  transition: margin 0.3s;
+}
 .ant-tabs-tabpane {
+  flex: none;
+  width: 100%;
   outline: none;
-}
-.ant-tabs-tabpane-hidden {
-  display: none;
-}
-.ant-tabs-switch-appear,
-.ant-tabs-switch-enter {
-  transition: none;
-}
-.ant-tabs-switch-appear-start,
-.ant-tabs-switch-enter-start {
-  opacity: 0;
-}
-.ant-tabs-switch-appear-active,
-.ant-tabs-switch-enter-active {
-  opacity: 1;
-  transition: opacity 0.3s;
-}
-.ant-tabs-switch-leave {
-  position: absolute;
-  transition: none;
-  inset: 0;
-}
-.ant-tabs-switch-leave-start {
-  opacity: 1;
-}
-.ant-tabs-switch-leave-active {
-  opacity: 0;
-  transition: opacity 0.3s;
 }
 .ant-tag {
   box-sizing: border-box;
@@ -24500,13 +24057,20 @@ tr.ant-table-expanded-row .ant-descriptions-view table {
   text-overflow: ellipsis;
 }
 .ant-transfer-list-content-item-remove {
+  color: #006aa3;
+  text-decoration: none;
+  outline: none;
+  cursor: pointer;
+  transition: color 0.3s;
   position: relative;
   color: #b3c2d3;
-  cursor: pointer;
-  transition: all 0.3s;
 }
+.ant-transfer-list-content-item-remove:focus,
 .ant-transfer-list-content-item-remove:hover {
   color: #006aa3;
+}
+.ant-transfer-list-content-item-remove:active {
+  color: #004d7d;
 }
 .ant-transfer-list-content-item-remove::after {
   position: absolute;
@@ -24515,6 +24079,9 @@ tr.ant-table-expanded-row .ant-descriptions-view table {
   bottom: -6px;
   left: -50%;
   content: '';
+}
+.ant-transfer-list-content-item-remove:hover {
+  color: #006aa3;
 }
 .ant-transfer-list-content-item:not(.ant-transfer-list-content-item-disabled):hover {
   background-color: #f1f5f9;
@@ -24938,9 +24505,6 @@ tr.ant-table-expanded-row .ant-descriptions-view table {
 }
 .ant-tree-treenode:hover .ant-tree .ant-tree-treenode-draggable .ant-tree-draggable-icon {
   opacity: 0.45;
-}
-.ant-tree .ant-tree-treenode-draggable.ant-tree-treenode-disabled .ant-tree-draggable-icon {
-  visibility: hidden;
 }
 .ant-tree-indent {
   align-self: stretch;
@@ -25421,9 +24985,6 @@ tr.ant-table-expanded-row .ant-descriptions-view table {
 .ant-select-tree-treenode:hover .ant-select-tree .ant-select-tree-treenode-draggable .ant-select-tree-draggable-icon {
   opacity: 0.45;
 }
-.ant-select-tree .ant-select-tree-treenode-draggable.ant-select-tree-treenode-disabled .ant-select-tree-draggable-icon {
-  visibility: hidden;
-}
 .ant-select-tree-indent {
   align-self: stretch;
   white-space: nowrap;
@@ -25586,7 +25147,7 @@ tr.ant-table-expanded-row .ant-descriptions-view table {
 }
 .ant-typography {
   color: #364a63;
-  word-break: break-word;
+  overflow-wrap: break-word;
 }
 .ant-typography.ant-typography-secondary {
   color: #63768f;
@@ -25728,13 +25289,14 @@ span.ant-typography-ellipsis {
 a.ant-typography,
 .ant-typography a {
   color: #006aa3;
+  text-decoration: none;
   outline: none;
   cursor: pointer;
   transition: color 0.3s;
   text-decoration: underline;
 }
-a.ant-typography:focus-visible,
-.ant-typography a:focus-visible,
+a.ant-typography:focus,
+.ant-typography a:focus,
 a.ant-typography:hover,
 .ant-typography a:hover {
   color: #006aa3;
@@ -25809,14 +25371,15 @@ a.ant-typography.ant-typography-disabled:active,
 .ant-typography-edit,
 .ant-typography-copy {
   color: #006aa3;
+  text-decoration: none;
   outline: none;
   cursor: pointer;
   transition: color 0.3s;
   margin-left: 4px;
 }
-.ant-typography-expand:focus-visible,
-.ant-typography-edit:focus-visible,
-.ant-typography-copy:focus-visible,
+.ant-typography-expand:focus,
+.ant-typography-edit:focus,
+.ant-typography-copy:focus,
 .ant-typography-expand:hover,
 .ant-typography-edit:hover,
 .ant-typography-copy:hover {
@@ -26427,7 +25990,6 @@ div.ant-typography-edit-content.ant-typography-rtl {
 .ant-upload-list .ant-upload-animate-inline-leave {
   animation-duration: 0.3s;
   animation-timing-function: cubic-bezier(0.78, 0.14, 0.15, 0.86);
-  animation-fill-mode: forwards;
 }
 .ant-upload-list .ant-upload-animate-inline-appear,
 .ant-upload-list .ant-upload-animate-inline-enter {
@@ -27042,6 +26604,9 @@ body {
 }
 .ant-form-item-label > label {
   font-weight: 500;
+}
+.ant-form-item-label > label .ant-form-item-tooltip {
+  cursor: default;
 }
 .ant-modal-confirm-warning .ant-modal-confirm-body > .anticon,
 .ant-modal-confirm-confirm .ant-modal-confirm-body > .anticon {


### PR DESCRIPTION
# FIX

- closes CLIN-2475 and CLIN-2511

## Description

[JIRA LINK](https://ferlab-crsj.atlassian.net/browse/CLIN-2475)
[JIRA LINK](https://ferlab-crsj.atlassian.net/browse/CLIN-2511)

Acceptance Criterias

## Validation

- [ ] Code Approved
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
### Before

### After
![Screenshot_20240124_121715](https://github.com/Ferlab-Ste-Justine/clin-portal-theme/assets/6180385/f3d9d18d-c8b9-4dfc-baf4-cce7ec0eec8d)

## QA

Steps to validate
Url (storybook, ...)
...

## Mention

@kstonge @luclemo
